### PR TITLE
[FIX] download file name Fix

### DIFF
--- a/apps_download/__manifest__.py
+++ b/apps_download/__manifest__.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 {
     "name": "Product Download for Appstore",
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.0.1",
     "author": "BizzAppDev, AgentERP, Elico Corp, "
     "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/apps-store",

--- a/apps_download/models/product_product.py
+++ b/apps_download/models/product_product.py
@@ -94,8 +94,8 @@ class ProductProduct(models.Model):
                     data_encode = base64.encodestring(file_obj.read())
                     self.env['ir.attachment'].create({
                         'datas': data_encode,
-                        'datas_fname':  (product.name + time_version_value +
-                                         '.zip'),
+                        'datas_fname':  (product.name.replace(" ", '-') +
+                                         time_version_value + '.zip'),
                         'type': 'binary',
                         'name': product.name + time_version_value + '.zip',
                         'res_model': product._name,

--- a/website_apps_store/controllers/main.py
+++ b/website_apps_store/controllers/main.py
@@ -191,7 +191,7 @@ class WebsiteSaleCustom(WebsiteSale):
 
         if attachment:
             filecontent = base64.b64decode(attachment.datas)
-            disposition = 'attachment; filename=%s' % attachment.datas_fname
+            disposition = 'attachment; filename="%s"' % attachment.datas_fname
             return request.make_response(
                 filecontent,
                 [('Content-Type', 'application/zip, application/octet-stream'),


### PR DESCRIPTION
Fix for the Download name.
in firefox it was not able to maintain full filename for Zip