### PR TITLE
[FIX]visibility for the selected options and filters improvements

### DIFF
--- a/website_apps_store/__manifest__.py
+++ b/website_apps_store/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 {
     "name": "Website Apps Store",
-    "version": "11.0.1.2.0",
+    "version": "11.0.2.2.0",
     'author': 'Odoo Community Association (OCA), BizzAppDev',
     "website": "https://github.com/OCA/apps-store",
     "license": "AGPL-3",

--- a/website_apps_store/controllers/main.py
+++ b/website_apps_store/controllers/main.py
@@ -86,6 +86,7 @@ class WebsiteSaleCustom(WebsiteSale):
         keep = QueryURL('/shop', category=category and int(category),
                         search=search, attrib=attrib_list,
                         order=post.get('order'),
+                        maturity=post.get('maturity'),
                         version=post.get('version'), author=post.get('author'))
         if post.get('version'):
             domain += [('product_variant_ids.attribute_value_ids.id',

--- a/website_apps_store/views/templates.xml
+++ b/website_apps_store/views/templates.xml
@@ -8,13 +8,19 @@
         <!--Shop Customization/-->
         <template id="category_display" name="Show Category by">
             <div class="dropdown btn-group dropdown_category_by">
+                <t t-set="selected_category" t-value="False"/>
+                <t t-foreach="category_all" t-as="cat">
+                    <t t-if="cat.id == int(category or 0)"
+                        t-set="selected_category" t-value="cat"/>
+                </t>
                 <a href="#" class="dropdown-toggle btn btn-default" data-toggle="dropdown">
-                    <span>Category</span>
+                    <span>Category : <t t-esc="(selected_category and
+                            selected_category.name) or 'All'"/></span>
                     <span class="caret"></span>
                 </a>
                 <ul class="dropdown-menu" role="menu">
                     <li t-att-class="'active' if not category else ''">
-                        <a href="/shop">All</a>
+                        <a t-att-href="keep('/shop/', category='')">All</a>
                     </li>
                     <t t-foreach="category_all" t-as="c">
                         <li t-att-class="'active' if c.id == int(category or 0) else None">
@@ -26,12 +32,18 @@
         </template>
         <template id="version_display" name="Show Version by">
             <div class="dropdown btn-group dropdown_version_by">
+                <t t-set="selected_version" t-value="False"/>
+                <t t-foreach="versions" t-as="ver">
+                    <t t-if="ver.id == int(version or 0)"
+                        t-set="selected_version" t-value="ver"/>
+                </t>
                 <a href="#" class="dropdown-toggle btn btn-default" data-toggle="dropdown">
-                    <span>Version</span>
+                    <span>Version : <t t-esc="(selected_version and
+                            selected_version.name) or 'All'"/></span>
                     <span class="caret"></span>
                 </a>
                 <ul class="dropdown-menu" role="menu">
-                    <li t-att-class="'active' if not version else None">
+                    <li t-att-class="'active' if not version else ''">
                         <a t-att-href="keep('/shop', version='')">All</a>
                     </li>
                     <t t-foreach="versions" t-as="v">
@@ -46,13 +58,22 @@
         </template>
         <template id="maturity_display">
             <div class="dropdown btn-group dropdown_maturity_by">
+                <t t-set="selected_maturity" t-value="False"/>
+                    <t t-if="maturity == 'alpha'"
+                        t-set="selected_maturity" t-value="'Alpha'"/>
+                    <t t-if="maturity == 'beta'"
+                        t-set="selected_maturity" t-value="'Beta'"/>
+                    <t t-if="maturity == 'production/stable'"
+                        t-set="selected_maturity" t-value="'Production/Stable'"/>
+                    <t t-if="maturity == 'mature'"
+                        t-set="selected_maturity" t-value="'Mature'"/>
                 <a href="#" class="dropdown-toggle btn btn-default" data-toggle="dropdown">
-                    <span>Maturity</span>
+                    <span>Maturity : <t t-esc="selected_maturity or 'All'"/></span>
                     <span class="caret"></span>
                 </a>
                 <ul class="dropdown-menu" role="menu">
                     <li t-att-class="'active' if not maturity else ''">
-                        <a t-att-href="keep('/shop', '')">All</a>
+                        <a t-att-href="keep('/shop', maturity='')">All</a>
                     </li>
                     <li t-att-class="'active' if maturity == 'alpha' else ''">
                         <a t-att-href="keep('/shop', maturity='alpha')">Alpha</a>


### PR DESCRIPTION
Changed things in this PR.

- Proper visibility for selected Filter (#41 )
- there was a possibility for missing selected filters when we have any 2 filters (from the category, version, maturity) enabled and we change version or category then maturity filter was lost. 
- All Category was clearing all other filters. now it will keep other filters.
