### PR TITLE
[FIX] webstie_apps_store: Icon sizes are now consistent

### DIFF
--- a/website_apps_store/views/templates.xml
+++ b/website_apps_store/views/templates.xml
@@ -148,6 +148,9 @@
             <xpath expr='//div[hasclass("product_price")]//span[@t-esc="product.website_price"]' position="replace">
                 <span t-esc="product.website_price" t-options="{'widget': 'monetary', 'display_currency': website.currency_id}" t-if="not product.odoo_module_id"/>
             </xpath>
+            <xpath expr="//span[@itemprop='image']" position="attributes">
+                <attribute name="t-options">{'widget': 'image', 'resize': None, 'zoom': 'image'}</attribute>
+            </xpath>
         </template>
 
         <!--Product Customization /-->


### PR DESCRIPTION
FIXES #28 

BEFORE
![image](https://user-images.githubusercontent.com/3836433/57197391-4d70e800-6f2c-11e9-9f53-1bf46e37245c.png)

AFTER
![image](https://user-images.githubusercontent.com/3836433/57197395-52359c00-6f2c-11e9-8f18-2ec1387a73c2.png)
