### PR TITLE
[MIG] apps_product_creator: Migration scripts

### DIFF
--- a/apps_product_creator/__manifest__.py
+++ b/apps_product_creator/__manifest__.py
@@ -1,4 +1,5 @@
-# Copyright (C) 2017-Today: Odoo Community Association (OCA)
+# Copyright 2017-2018 Odoo Community Association (OCA)
+# Copyright 2019 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'Github product creator',

--- a/apps_product_creator/data/product_attribute.xml
+++ b/apps_product_creator/data/product_attribute.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--Copyright (C) 2017-Today: Odoo Community Association (OCA)-->
+<!--Copyright 2017-Today Odoo Community Association (OCA)
+    Copyright 2019 Tecnativa - Pedro M. Baeza -->
 <!--License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).-->
 <odoo noupdate="1">
 
@@ -46,8 +47,19 @@
         <field name="name">11.0</field>
         <field name="attribute_id" ref="attribute_odoo_version"/>
     </record>
+
     <record id="odoo_version_120" model="product.attribute.value">
         <field name="name">12.0</field>
+        <field name="attribute_id" ref="attribute_odoo_version"/>
+    </record>
+
+    <record id="odoo_version_130" model="product.attribute.value">
+        <field name="name">13.0</field>
+        <field name="attribute_id" ref="attribute_odoo_version"/>
+    </record>
+
+    <record id="odoo_version_140" model="product.attribute.value">
+        <field name="name">14.0</field>
         <field name="attribute_id" ref="attribute_odoo_version"/>
     </record>
 

--- a/apps_product_creator/migrations/12.0.1.0.0/pre-migration.py
+++ b/apps_product_creator/migrations/12.0.1.0.0/pre-migration.py
@@ -1,0 +1,28 @@
+# Copyright 2019 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+def assign_new_version_attribute_xml_id(env):
+    """This checks if 12.0 attribute has been manually added in previous
+    version, so assigning the XML-ID for avoiding duplicate constraint error.
+    """
+    attrib = env.ref('apps_product_creator.attribute_odoo_version')
+    value = env['product.attribute.value'].search([
+        ('attribute_id', '=', attrib.id),
+        ('name', '=', '12.0'),
+    ])
+    if value:
+        env['ir.model.data'].create({
+            'module': 'apps_product_creator',
+            'name': 'odoo_version_120',
+            'model': value._name,
+            'res_id': value.id,
+            'noupdate': True,
+        })
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    assign_new_version_attribute_xml_id(env)


### PR DESCRIPTION
* Add XML-ID if 12.0 attribute value was manually added in the DB
* Add in advance 13.0 and 14.0 attribute versions for avoiding this problem in future versions

cc @Tecnativa