### PR TITLE
[IMP] attachment generation cron

### DIFF
--- a/apps_download/views/product_template_view.xml
+++ b/apps_download/views/product_template_view.xml
@@ -18,6 +18,7 @@
                         <field name="dependent_product_ids" colspan="4" nolabel="1"/>
                         <button string="Get all Dependencies" type="object" name="generate_zip_file"/>
                         <field name="module_path"/>
+                        <field name="module_zip_generate_date"/>
                     </page>
                 </xpath>
             </field>


### PR DESCRIPTION
* generate attachments by batches of 500 products, starting from the
most ancient attachment
* remove the previous version of the attachment

TODO
* use the version number of the module in the zip name rather than the
current date
* only regenerate if the module version has changed