### PR TITLE
[13.0] apps_download + apps_product_creator: Several fixes and improvements

### DIFF
--- a/apps_download/models/product_product.py
+++ b/apps_download/models/product_product.py
@@ -18,13 +18,6 @@ _logger = logging.getLogger(__name__)
 class ProductProduct(models.Model):
     _inherit = "product.product"
 
-    dependent_product_ids = fields.Many2many(
-        "product.product",
-        "product_product_dependent_rel",
-        "src_id",
-        "dest_id",
-        string="Dependent Products",
-    )
     module_path = fields.Char(
         related="odoo_module_version_id.repository_branch_id.local_path", readonly=True
     )

--- a/apps_download/models/product_product.py
+++ b/apps_download/models/product_product.py
@@ -10,7 +10,7 @@ import tempfile
 import time
 
 from odoo import _, api, fields, models
-from odoo.exceptions import ValidationError
+from odoo.exceptions import UserError, ValidationError
 
 _logger = logging.getLogger(__name__)
 
@@ -79,7 +79,16 @@ class ProductProduct(models.Model):
                 tmp_dir, product.odoo_module_version_id.technical_name
             )
             module_path = product._get_module_path()
-            shutil.copytree(module_path, tmp_module_path)
+            try:
+                shutil.copytree(module_path, tmp_module_path)
+            except FileNotFoundError:
+                raise UserError(
+                    _(
+                        "Module code not downloaded yet."
+                        " Please initialize the code in the associated"
+                        " Github Repository Branch by downloading the source code."
+                    )
+                )
             time_version_value = time.strftime("_%y%m%d_%H%M%S")
             attr_values = product.product_template_attribute_value_ids
             if attr_values:

--- a/apps_download/models/product_product.py
+++ b/apps_download/models/product_product.py
@@ -81,13 +81,11 @@ class ProductProduct(models.Model):
             module_path = product._get_module_path()
             shutil.copytree(module_path, tmp_module_path)
             time_version_value = time.strftime("_%y%m%d_%H%M%S")
-            if product.attribute_value_ids:
+            attr_values = product.product_template_attribute_value_ids
+            if attr_values:
                 time_version_value = "_{}{}".format(
                     "_".join(
-                        [
-                            name.replace(".", "_")
-                            for name in product.attribute_value_ids.mapped("name")
-                        ]
+                        [name.replace(".", "_") for name in attr_values.mapped("name")]
                     ),
                     time_version_value,
                 )

--- a/apps_product_creator/models/product_product.py
+++ b/apps_product_creator/models/product_product.py
@@ -85,6 +85,13 @@ class ProductProduct(models.Model):
         related="odoo_module_version_id.development_status",
         store=True,
     )
+    dependent_product_ids = fields.Many2many(
+        "product.product",
+        "product_product_dependent_rel",
+        "src_id",
+        "dest_id",
+        string="Dependent Products",
+    )
 
     @api.depends(
         "odoo_module_version_id", "odoo_module_version_id.description_rst_html"

--- a/apps_product_creator/models/product_product.py
+++ b/apps_product_creator/models/product_product.py
@@ -244,6 +244,7 @@ class ProductProduct(models.Model):
         attributes = attr_obj.browse(attr_ids)
         # We should have 0 or 1 result maximum. Because we compare id.
         attribute = attributes.filtered(
-            lambda a: a.product_attribute_value_id.id == version_attribute.id
+            lambda a: a.product_attribute_value_id.attribute_id.id
+            == version_attribute.id
         )
         return attribute.product_attribute_value_id


### PR DESCRIPTION
### [FIX] apps_product_creator: Check correct attribute

A `product.attribute.value` was being compared to a `product.attribute`
This makes the correct association to avoid errors

### [FIX] apps_download: Check correct attribute

`product.product` has no `attribute_value_ids`, causing errors like [13.0] apps_download: Error while trying to download an app (base_import_async) #80 (Closes #80)

This checks the correct `product_template_attribute_value_ids` associated

### [IMP] apps_download: better error message

Give a proper warning when the module's code does not exist in disk yet instead of an exception

### [FIX] apps_product_creator: Add dependent_product_ids
    
This field is needed in this module but was only being declared in the `apps_download` module. `apps_download` depends on this, so we can move the field declaration here.

@Tecnativa
TT30343

@pedrobaeza can you review please?



