### PR TITLE
[13.0][FIX] apps_download: Create ir.attachment correctly

### DIFF
--- a/apps_download/models/product_product.py
+++ b/apps_download/models/product_product.py
@@ -101,7 +101,7 @@ class ProductProduct(models.Model):
                     self.env["ir.attachment"].create(
                         {
                             "datas": data_encode,
-                            "datas_fname": (
+                            "store_fname": (
                                 product.name.replace(" ", "-")
                                 + time_version_value
                                 + ".zip"


### PR DESCRIPTION
Missing step from migration. Field `datas_fname` is no longer used for `ir.attachment`.

@Tecnativa
TT30343

ping @pedrobaeza @sbidoul 