### PR TITLE
[FIX] website_apps_store: error when shopping without category

### DIFF
--- a/website_apps_store/controllers/main.py
+++ b/website_apps_store/controllers/main.py
@@ -129,8 +129,8 @@ class WebsiteSaleCustom(WebsiteSale):
         if attrib_list:
             post["attrib"] = attrib_list
 
+        category = request.env["product.public.category"].browse(int(category or 0))
         if category:
-            category = request.env["product.public.category"].browse(int(category))
             url = "/shop/category/%s" % slug(category)
 
         attribute_id = request.env.ref("apps_product_creator.attribute_odoo_version")


### PR DESCRIPTION
When opening the shopping page without filters, an error is raised. That's
because, when no category is provided to filter, it's not handled
correctly.

To solve the above, this change ensures the category is always provided
as a recordset, as required by Odoo in newer versions [1].

[1] https://github.com/odoo/odoo/commit/930238404de8