### PR TITLE
[FIX] apps_product_creator: activate and publish modules that come back

### DIFF
--- a/apps_product_creator/models/odoo_module.py
+++ b/apps_product_creator/models/odoo_module.py
@@ -43,23 +43,34 @@ class OdooModule(models.Model):
         Create the product template related to the module in current recordset.
         :return: product.template recordset
         """
-        product_obj = self.env["product.template"]
-        products = self.env["product.template"]
-        modules = self.filtered(lambda m: not m.product_template_id)
+        new_products = self.env["product.template"]
+        modules_without_product_template = self.filtered(
+            lambda m: not m.product_template_id
+        )
         domain = [
-            ("odoo_module_id", "in", modules.ids),
+            ("odoo_module_id", "in", modules_without_product_template.ids),
         ]
-        matching_products = product_obj.search(domain)
-        for odoo_module in modules:
+        matching_products = (
+            self.env["product.template"].with_context(active_test=False).search(domain)
+        )
+        for odoo_module in modules_without_product_template:
             product = matching_products.filtered(
                 lambda p: p.odoo_module_id == odoo_module
             )
+            # odoo_module_id and product_template_id are set in the same
+            # transaction this condition is mainly true in most cases
             if not product and not odoo_module.product_template_id:
                 product_values = odoo_module._prepare_template()
-                new_product = product_obj.create(product_values)
+                new_product = self.env["product.template"].create(product_values)
                 odoo_module.write({"product_template_id": new_product.id})
-                products |= new_product
-        return products
+                new_products |= new_product
+        self.product_template_id.write(
+            {
+                "active": True,
+                "website_published": True,
+            }
+        )
+        return new_products
 
     def _update_product(self):
         attribute = self.env.ref("apps_product_creator.attribute_odoo_version")
@@ -81,6 +92,8 @@ class OdooModule(models.Model):
             )
             att_line.write({"value_ids": [[4, record.id] for record in att_val_ids]})
             product._create_variant_ids()
+            product.active = True
+            product.website_published = True
 
     @api.model
     def _update_series_product_attribute_values(self):

--- a/apps_product_creator/tests/test_apps_product_creator.py
+++ b/apps_product_creator/tests/test_apps_product_creator.py
@@ -1,44 +1,45 @@
 # Copyright (C) 2017-Today: Odoo Community Association (OCA)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import SavepointCase
 from odoo.tools import config
 
 
-class TestAppsProductCreator(TransactionCase):
-    def setUp(self):
-        super().setUp()
+class TestAppsProductCreator(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
         # Trick this configuration value for avoiding an error
         config["source_code_local_path"] = "/tmp/"
-        self.organization1 = self.env["github.organization"].create(
+        cls.organization1 = cls.env["github.organization"].create(
             {"name": "Organization 1", "github_name": "login"}
         )
 
-        self.organization_serie1 = self.env["github.organization.serie"].create(
-            {"name": "12.0", "sequence": 1, "organization_id": self.organization1.id}
+        cls.organization_serie1 = cls.env["github.organization.serie"].create(
+            {"name": "12.0", "sequence": 1, "organization_id": cls.organization1.id}
         )
 
-        self.repository1 = self.env["github.repository"].create(
-            {"name": "Repository1", "organization_id": self.organization1.id}
+        cls.repository1 = cls.env["github.repository"].create(
+            {"name": "Repository1", "organization_id": cls.organization1.id}
         )
 
-        self.branch1 = self.env["github.repository.branch"].create(
+        cls.branch1 = cls.env["github.repository.branch"].create(
             {
                 "name": "12.0",
-                "repository_id": self.repository1.id,
-                "organization_id": self.organization1.id,
+                "repository_id": cls.repository1.id,
+                "organization_id": cls.organization1.id,
             }
         )
 
-        self.odoo_module2 = self.env["odoo.module"].create(
+        cls.odoo_module2 = cls.env["odoo.module"].create(
             {"technical_name": "odoo_module2"}
         )
 
-        self.odoo_module1_version2 = self.env["odoo.module.version"].create(
+        cls.odoo_module1_version2 = cls.env["odoo.module.version"].create(
             {
                 "name": "Odoo Module 2",
                 "technical_name": "odoo_module2",
-                "module_id": self.odoo_module2.id,
-                "repository_branch_id": self.branch1.id,
+                "module_id": cls.odoo_module2.id,
+                "repository_branch_id": cls.branch1.id,
                 "license": "AGPL-3",
                 "summary": "Summary Test",
                 "website": "Website Test",
@@ -51,21 +52,21 @@ class TestAppsProductCreator(TransactionCase):
             }
         )
 
-        self.odoo_module1 = self.env["odoo.module"].create(
+        cls.odoo_module1 = cls.env["odoo.module"].create(
             {
                 "technical_name": "odoo_module1",
                 "dependence_module_version_ids": [
-                    (6, 0, [self.odoo_module1_version2.id])
+                    (6, 0, [cls.odoo_module1_version2.id])
                 ],
             }
         )
 
-        self.odoo_module1_version1 = self.env["odoo.module.version"].create(
+        cls.odoo_module1_version1 = cls.env["odoo.module.version"].create(
             {
                 "name": "Odoo Module 1",
                 "technical_name": "odoo_module1",
-                "module_id": self.odoo_module1.id,
-                "repository_branch_id": self.branch1.id,
+                "module_id": cls.odoo_module1.id,
+                "repository_branch_id": cls.branch1.id,
                 "license": "AGPL-3",
                 "summary": "Summary Test",
                 "website": "Website Test",
@@ -77,6 +78,7 @@ class TestAppsProductCreator(TransactionCase):
                 "full_module_path": "/repo/10.0/odoo_module_1",
             }
         )
+        cls.odoo_module2.action_create_product()
 
     def test1_product_create(self):
         self.assertFalse(self.odoo_module1.product_template_id)
@@ -87,3 +89,21 @@ class TestAppsProductCreator(TransactionCase):
             self.odoo_module1.product_template_id.product_variant_ids.ids[0],
             action["res_id"],
         )
+
+    def test_process_clean_module_version(self):
+        self.assertTrue(self.odoo_module2.product_template_id)
+        self.odoo_module1_version2._process_clean_module_version()
+        self.assertFalse(self.odoo_module1.product_template_id.active)
+        self.assertFalse(self.odoo_module1.product_template_id.website_published)
+
+    def test_action_create_product_active_product(self):
+        self.odoo_module1_version2._process_clean_module_version()
+        self.odoo_module2.action_create_product()
+        self.assertTrue(self.odoo_module2.product_template_id.active)
+        self.assertTrue(self.odoo_module2.product_template_id.website_published)
+
+    def test_odoo_module_update_product(self):
+        self.odoo_module1_version2._process_clean_module_version()
+        self.odoo_module2._update_product()
+        self.assertTrue(self.odoo_module2.product_template_id.active)
+        self.assertTrue(self.odoo_module2.product_template_id.website_published)


### PR DESCRIPTION
In some case were product template has been archived and unpublished, while module come back active in a given set of module, ensure product is active and published.

This is part of the internal tools working group task id #871849